### PR TITLE
Include additional kwargs as @sqlserver_options

### DIFF
--- a/lib/active_record/connection_adapters/sqlserver_column.rb
+++ b/lib/active_record/connection_adapters/sqlserver_column.rb
@@ -2,8 +2,8 @@ module ActiveRecord
   module ConnectionAdapters
     class SQLServerColumn < Column
 
-      def initialize(name, default, sql_type_metadata = nil, null = true, table_name = nil, default_function = nil, collation = nil, comment = nil, **)
-        @sqlserver_options = {}
+      def initialize(name, default, sql_type_metadata = nil, null = true, table_name = nil, default_function = nil, collation = nil, comment = nil, **sqlserver_options)
+        @sqlserver_options = sqlserver_options
         @name = name.freeze
         @sql_type_metadata = sql_type_metadata
         @null = null


### PR DESCRIPTION
A previous commit resulted in this being hardcoded as `{}` which resulted in many column query issues (i.e. `is_identity?`) that rely on that ivar.